### PR TITLE
Bugfix: wrong size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 
 project(openexr-viewer 
-    VERSION 0.4
+    VERSION 0.4.1
     DESCRIPTION "Simple Viewer for OpenEXR files with detailed metadata display"
     HOMEPAGE_URL "https://github.com/afichet/openexr-viewer"
     LANGUAGES CXX 

--- a/deploy/linux/openexr-viewer.desktop
+++ b/deploy/linux/openexr-viewer.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
-Version=0.4
+Version=0.4.1
 Name=OpenEXR Viewer
 Comment=Viewer for OpenEXR images
 Icon=openexr-viewer

--- a/deploy/linux/openexr-viewer.metainfo.xml
+++ b/deploy/linux/openexr-viewer.metainfo.xml
@@ -11,6 +11,7 @@
   </description>
   <launchable type="desktop-id">openexr-viewer.desktop</launchable>
   <releases>
+    <release date="2021-06-29" version="0.4.1"/>
     <release date="2021-05-30" version="0.4"/>
     <release date="2021-05-22" version="0.3"/>
   </releases>

--- a/src/model/HeaderModel.cpp
+++ b/src/model/HeaderModel.cpp
@@ -317,8 +317,12 @@ HeaderItem *HeaderModel::addItem(
       part_number,
       name);
 
+
+    const int width  = attr.value().max.x - attr.value().min.x + 1;
+    const int height = attr.value().max.y - attr.value().min.y + 1;
+
     std::stringstream sWidth;
-    sWidth << attr.value().size().x;
+    sWidth << width;
 
     new HeaderItem(
       attrItem,
@@ -328,7 +332,7 @@ HeaderItem *HeaderModel::addItem(
       name);
 
     std::stringstream sHeight;
-    sHeight << attr.value().size().y;
+    sHeight << height;
 
     new HeaderItem(
       attrItem,
@@ -376,8 +380,11 @@ HeaderItem *HeaderModel::addItem(
       part_number,
       name);
 
+    const float width  = attr.value().max.x - attr.value().min.x + 1;
+    const float height = attr.value().max.y - attr.value().min.y + 1;
+
     std::stringstream sWidth;
-    sWidth << attr.value().size().x;
+    sWidth << width;
 
     new HeaderItem(
       attrItem,
@@ -387,7 +394,7 @@ HeaderItem *HeaderModel::addItem(
       name);
 
     std::stringstream sHeight;
-    sHeight << attr.value().size().y;
+    sHeight << height;
 
     new HeaderItem(
       attrItem,


### PR DESCRIPTION
The width and height fields were using size() and wrongly displayed width and height of a vec2i and vec2f