### PR TITLE
Fix segfault

### DIFF
--- a/src/model/framebuffer/FramebufferModel.cpp
+++ b/src/model/framebuffer/FramebufferModel.cpp
@@ -39,7 +39,6 @@
 
 FramebufferModel::FramebufferModel(QObject* parent)
   : QObject(parent)
-  , m_pixelBuffer(nullptr)
   , m_width(0)
   , m_height(0)
   , m_isImageLoaded(false)
@@ -59,7 +58,4 @@ QRect FramebufferModel::getDataWindow() const
     return m_dataWindow;
 }
 
-FramebufferModel::~FramebufferModel()
-{
-    delete[] m_pixelBuffer;
-}
+FramebufferModel::~FramebufferModel() {}

--- a/src/model/framebuffer/FramebufferModel.h
+++ b/src/model/framebuffer/FramebufferModel.h
@@ -70,6 +70,8 @@ class FramebufferModel: public QObject
     float* m_pixelBuffer;
     QImage m_image;
 
+    // Right now, the width and height are defined as Vec2i in OpenEXR
+    // i.e. int type.
     int m_width, m_height;
 
     bool m_isImageLoaded;

--- a/src/model/framebuffer/FramebufferModel.h
+++ b/src/model/framebuffer/FramebufferModel.h
@@ -37,7 +37,7 @@
 #include <QObject>
 #include <QRect>
 #include <QVector>
-#include <array>
+#include <vector>
 
 class FramebufferModel: public QObject
 {
@@ -67,8 +67,8 @@ class FramebufferModel: public QObject
     void loadFailed(QString message);
 
   protected:
-    float* m_pixelBuffer;
-    QImage m_image;
+    std::vector<float> m_pixelBuffer;
+    QImage             m_image;
 
     // Right now, the width and height are defined as Vec2i in OpenEXR
     // i.e. int type.

--- a/src/model/framebuffer/YFramebufferModel.cpp
+++ b/src/model/framebuffer/YFramebufferModel.cpp
@@ -90,12 +90,25 @@ void YFramebufferModel::load(Imf::MultiPartInputFile& file, int partId)
                   dispW_width / 2,
                   dispW_height / 2);
 
-                m_pixelBuffer = new float[m_width * m_height];
+                // Check to avoid type overflow, width and height are 32bits int
+                // representing a 2 dimentional image. Can overflow the type when
+                // multiplied together
+                // TODO: Use larger type when manipulating framebuffer
+                const uint64_t partial_size
+                  = (uint64_t)m_width * (uint64_t)m_height;
+
+                if (partial_size > 0x7FFFFFFF) {
+                    throw std::runtime_error(
+                      "The total image size is too large. May be supported in "
+                      "a future revision.");
+                }
+
+                m_pixelBuffer.resize(m_width * m_height);
 
                 // Luminance Chroma channels
                 graySlice = Imf::Slice::Make(
                   Imf::PixelType::FLOAT,
-                  m_pixelBuffer,
+                  m_pixelBuffer.data(),
                   datW,
                   sizeof(float),
                   m_width * sizeof(float),
@@ -112,11 +125,11 @@ void YFramebufferModel::load(Imf::MultiPartInputFile& file, int partId)
                 m_displayWindow
                   = QRect(dispW.min.x, dispW.min.y, dispW_width, dispW_height);
 
-                m_pixelBuffer = new float[m_width * m_height];
+                m_pixelBuffer.resize(m_width * m_height);
 
                 graySlice = Imf::Slice::Make(
                   Imf::PixelType::FLOAT,
-                  m_pixelBuffer,
+                  m_pixelBuffer.data(),
                   datW);
             }
 


### PR DESCRIPTION
When the total memory required to store the whole image exceeds the upper int limit, in many places, there is memory violation #43.

This PR prevent this issue by performing an early check on the required memory size prior to allocation and access. Future revision shall handle such files by using larger types.